### PR TITLE
Update Appium dependency to v5

### DIFF
--- a/samples/UITests.Android/UITests.Android.csproj
+++ b/samples/UITests.Android/UITests.Android.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Appium.WebDriver" Version="5.0.0-rc.7" />
+		<PackageReference Include="Appium.WebDriver" Version="5.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="NUnit" Version="4.1.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/samples/UITests.Windows/UITests.Windows.csproj
+++ b/samples/UITests.Windows/UITests.Windows.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Appium.WebDriver" Version="5.0.0-rc.7" />
+		<PackageReference Include="Appium.WebDriver" Version="5.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="NUnit" Version="4.1.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/samples/UITests.iOS/UITests.iOS.csproj
+++ b/samples/UITests.iOS/UITests.iOS.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Appium.WebDriver" Version="5.0.0-rc.7" />
+		<PackageReference Include="Appium.WebDriver" Version="5.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="NUnit" Version="4.1.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/samples/UITests.macOS/UITests.macOS.csproj
+++ b/samples/UITests.macOS/UITests.macOS.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Appium.WebDriver" Version="5.0.0-rc.7" />
+		<PackageReference Include="Appium.WebDriver" Version="5.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
 		<PackageReference Include="NUnit" Version="4.1.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />

--- a/src/Plugin.Maui.UITestHelpers.Appium/Actions/AppiumLifecycleActions.cs
+++ b/src/Plugin.Maui.UITestHelpers.Appium/Actions/AppiumLifecycleActions.cs
@@ -1,4 +1,5 @@
 ﻿using OpenQA.Selenium.Appium.Android;
+using OpenQA.Selenium.Appium.Windows;
 using Plugin.Maui.UITestHelpers.Core;
 
 namespace Plugin.Maui.UITestHelpers.Appium

--- a/src/Plugin.Maui.UITestHelpers.Appium/Actions/AppiumLifecycleActions.cs
+++ b/src/Plugin.Maui.UITestHelpers.Appium/Actions/AppiumLifecycleActions.cs
@@ -60,11 +60,13 @@ namespace Plugin.Maui.UITestHelpers.Appium
 					{ "bundleId", _app.GetAppId() },
 				});
 			}
-			else if (_app.GetTestDevice() == TestDevice.Windows)
+			else if (_app.Driver is WindowsDriver windowsDriver)
 			{
-#pragma warning disable CS0618 // Type or member is obsolete
-				_app.Driver.LaunchApp();
-#pragma warning restore CS0618 // Type or member is obsolete
+				// Appium driver removed the LaunchApp method in 5.0.0, so we need to use the executeScript method instead
+				// Currently the appium-windows-driver reports the following commands as compatible:
+				//   startRecordingScreen,stopRecordingScreen,launchApp,closeApp,deleteFile,deleteFolder,
+				//   click,scroll,clickAndDrag,hover,keys,setClipboard,getClipboard
+				windowsDriver.ExecuteScript("windows: launchApp", [_app.GetAppId()]);
 			}
 			else
 			{
@@ -122,11 +124,12 @@ namespace Plugin.Maui.UITestHelpers.Appium
 					{ "bundleId", _app.GetAppId() },
 				});
 			}
-			else if (_app.GetTestDevice() == TestDevice.Windows)
+			else if (_app.Driver is WindowsDriver windowsDriver)
 			{
-#pragma warning disable CS0618 // Type or member is obsolete
-				_app.Driver.CloseApp();
-#pragma warning restore CS0618 // Type or member is obsolete
+				// This is still here for now, but it looks like it will get removed just like
+				// LaunchApp was in 5.0.0, in which case we may need to use:
+				// windowsDriver.ExecuteScript("windows: closeApp", [_app.GetAppId()]);
+				windowsDriver.CloseApp();
 			}
 			else
 				_app.Driver.TerminateApp(_app.GetAppId());

--- a/src/Plugin.Maui.UITestHelpers.Appium/Plugin.Maui.UITestHelpers.Appium.csproj
+++ b/src/Plugin.Maui.UITestHelpers.Appium/Plugin.Maui.UITestHelpers.Appium.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Appium.WebDriver" Version="5.0.0-rc.7" />
+    <PackageReference Include="Appium.WebDriver" Version="5.0.0" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.3" />
   </ItemGroup>
 

--- a/src/Plugin.Maui.UITestHelpers.Appium/Plugin.Maui.UITestHelpers.Appium.csproj
+++ b/src/Plugin.Maui.UITestHelpers.Appium/Plugin.Maui.UITestHelpers.Appium.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="5.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.3" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumps Appium dependency to v5 stable and adds fixes for breaking changes, also applied in MAUI [here](https://github.com/dotnet/maui/pull/23118).

Fixes #19