### PR TITLE
IsSelected() does not return value of checkbox on Android, iOS, or Mac

### DIFF
--- a/samples/Plugin.Maui.UITestHelpers.Sample/MainPage.xaml
+++ b/samples/Plugin.Maui.UITestHelpers.Sample/MainPage.xaml
@@ -6,7 +6,7 @@
     <ScrollView>
         <VerticalStackLayout
             Padding="30,0"
-            Spacing="25">
+            Spacing="20">
             <Image
                 Source="dotnet_bot.png"
                 HeightRequest="185"
@@ -31,6 +31,17 @@
                 SemanticProperties.Hint="Counts the number of times you click"
                 Clicked="OnCounterClicked"
                 HorizontalOptions="Fill" />
+
+            <HorizontalStackLayout>
+                <CheckBox AutomationId="CB1" IsChecked="True"/>
+                <CheckBox AutomationId="CB2"/>
+            </HorizontalStackLayout>
+
+            <HorizontalStackLayout>
+                <RadioButton Content="Cat" AutomationId="RB1" IsChecked="True"/>
+                <RadioButton Content="Dog" AutomationId="RB2" />
+            </HorizontalStackLayout>
+
         </VerticalStackLayout>
     </ScrollView>
 

--- a/samples/UITests.Shared/MainPageTests.cs
+++ b/samples/UITests.Shared/MainPageTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
-using Plugin.Maui.UITestHelpers.Core;
+using NUnit.Framework.Legacy;
 using Plugin.Maui.UITestHelpers.Appium;
+using Plugin.Maui.UITestHelpers.Core;
 
 namespace UITests.Shared;
 
@@ -11,27 +12,95 @@ public class MainPageTests : BaseTest
     }
 
     [Test]
-	public void AppLaunches()
-	{
-		App.Screenshot($"{nameof(AppLaunches)}.png");
-	}
+    public void AppLaunches()
+    {
+        App.Screenshot($"{nameof(AppLaunches)}.png");
+    }
 
-	[Test]
-	public void ClickCounterTest()
-	{
-		const string elementId = "CounterBtn";
+    [Test]
+    public void ClickCounterTest()
+    {
+        const string elementId = "CounterBtn";
 
-		// Arrange
-		// Find elements with the value of the AutomationId property
-		var element = App.FindElement(elementId);
-		App.WaitForElement(elementId);
+        // Arrange
+        // Find elements with the value of the AutomationId property
+        var element = App.FindElement(elementId);
+        App.WaitForElement(elementId);
 
-		// Act
-		element.Click();
-		Task.Delay(500).Wait(); // Wait for the click to register and show up on the screenshot
+        // Act
+        element.Click();
+        Task.Delay(500).Wait(); // Wait for the click to register and show up on the screenshot
 
-		// Assert
-		App.Screenshot($"{nameof(ClickCounterTest)}.png");
-		Assert.That(element.GetText(), Is.EqualTo("Clicked 1 time"));
-	}
+        // Assert
+        App.Screenshot($"{nameof(ClickCounterTest)}.png");
+        Assert.That(element.GetText(), Is.EqualTo("Clicked 1 time"));
+    }
+
+    [Test]
+    public void CheckBox_CheckboxChecked_IsCheckedReturnsTrue()
+    {
+        const string elementId = "CB1";
+
+        // Arrange
+        var element = App.FindElement(elementId);
+        App.WaitForElement(elementId);
+
+        // Act
+        bool isChecked = element.IsChecked(App.GetTestDevice());
+
+        // Assert
+        App.Screenshot($"{nameof(CheckBox_CheckboxChecked_IsCheckedReturnsTrue)}.png");
+        ClassicAssert.IsTrue(isChecked);
+    }
+
+    [Test]
+    public void CheckBox_CheckboxNotChecked_IsCheckedReturnsFalse()
+    {
+        const string elementId = "CB2";
+
+        // Arrange
+        var element = App.FindElement(elementId);
+        App.WaitForElement(elementId);
+
+        // Act
+        bool isChecked = element.IsChecked(App.GetTestDevice());
+
+        // Assert
+        App.Screenshot($"{nameof(CheckBox_CheckboxNotChecked_IsCheckedReturnsFalse)}.png");
+        ClassicAssert.IsFalse(isChecked);
+    }
+
+    [Test]
+    public void RadioButton_RadioButtonChecked_IsCheckedReturnsTrue()
+    {
+        const string elementId = "RB1";
+
+        // Arrange
+        var element = App.FindElement(elementId);
+        App.WaitForElement(elementId);
+
+        // Act
+        bool isChecked = element.IsChecked(App.GetTestDevice());
+
+        // Assert
+        App.Screenshot($"{nameof(RadioButton_RadioButtonChecked_IsCheckedReturnsTrue)}.png");
+        ClassicAssert.IsTrue(isChecked);
+    }
+
+    [Test]
+    public void RadioButton_RadioButtonNotChecked_IsCheckedReturnsFalse()
+    {
+        const string elementId = "RB2";
+
+        // Arrange
+        var element = App.FindElement(elementId);
+        App.WaitForElement(elementId);
+
+        // Act
+        bool isChecked = element.IsSelected();
+
+        // Assert
+        App.Screenshot($"{nameof(RadioButton_RadioButtonNotChecked_IsCheckedReturnsFalse)}.png");
+        ClassicAssert.IsFalse(isChecked);
+    }
 }

--- a/src/Plugin.Maui.UITestHelpers.Appium/Actions/AppiumGeneralActions.cs
+++ b/src/Plugin.Maui.UITestHelpers.Appium/Actions/AppiumGeneralActions.cs
@@ -10,6 +10,7 @@ namespace Plugin.Maui.UITestHelpers.Appium
         const string GetSelectedCommand = "getSelected";
         const string GetDisplayedCommand = "getDisplayed";
         const string GetEnabledCommand = "getEnabled";
+        const string GetCheckedCommand = "getChecked";
 
         readonly List<string> _commands = new()
         {
@@ -18,6 +19,7 @@ namespace Plugin.Maui.UITestHelpers.Appium
             GetSelectedCommand,
             GetDisplayedCommand,
             GetEnabledCommand,
+            GetCheckedCommand
         };
 
         public bool IsCommandSupported(string commandName)
@@ -34,6 +36,7 @@ namespace Plugin.Maui.UITestHelpers.Appium
                 GetSelectedCommand => GetSelected(parameters),
                 GetDisplayedCommand => GetDisplayed(parameters),
                 GetEnabledCommand => GetEnabled(parameters),
+                GetCheckedCommand => GetChecked(parameters),
                 _ => CommandResponse.FailedEmptyResponse,
             };
         }
@@ -112,6 +115,29 @@ namespace Plugin.Maui.UITestHelpers.Appium
             else if (element is AppiumDriverElement driverElement)
             {
                 return new CommandResponse(driverElement.AppiumElement.Enabled, CommandResponseResult.Success);
+            }
+
+            return CommandResponse.FailedEmptyResponse;
+        }
+
+        CommandResponse GetChecked(IDictionary<string, object> parameters)
+        {
+            var element = parameters["element"];
+            TestDevice testDevice = (TestDevice)parameters["testdevice"];
+
+            if (testDevice == TestDevice.Android)
+            {
+                parameters.Add("attributeName", "checked");
+                return GetAttribute(parameters);
+            }
+            else if (testDevice == TestDevice.iOS || testDevice == TestDevice.Mac)
+            {
+                parameters.Add("attributeName", "value");
+                return GetAttribute(parameters);
+            }
+            else if (testDevice == TestDevice.Windows)
+            {
+                return GetSelected(parameters);
             }
 
             return CommandResponse.FailedEmptyResponse;

--- a/src/Plugin.Maui.UITestHelpers.Appium/HelperExtensions.cs
+++ b/src/Plugin.Maui.UITestHelpers.Appium/HelperExtensions.cs
@@ -1,9 +1,9 @@
-using System.Collections.Immutable;
-using System.Diagnostics;
-using System.Drawing;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Interfaces;
 using Plugin.Maui.UITestHelpers.Core;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Drawing;
 
 namespace Plugin.Maui.UITestHelpers.Appium
 {
@@ -92,6 +92,36 @@ namespace Plugin.Maui.UITestHelpers.Appium
         }
 
         /// <summary>
+        /// Determine if an element such as a Checkbox or RadioButton is checked.
+        /// </summary>
+        /// <param name="element">Target Element.</param>
+        /// <param name="testDevice">Target Platform.</param>
+        /// <returns>Whether the element is checked (boolean).</returns>
+        public static bool IsChecked(this IUIElement element, TestDevice testDevice)
+        {
+            var response = element.Command.Execute("getChecked", new Dictionary<string, object>()
+             {
+                 { "element", element },
+                 { "testdevice", testDevice }
+             });
+
+            if (response?.Value != null)
+            {
+                if (testDevice == TestDevice.Android)
+                {
+                    return Convert.ToBoolean(response.Value);
+                }
+                else if (testDevice == TestDevice.Mac || testDevice == TestDevice.iOS)
+                {
+                    return Convert.ToBoolean(Convert.ToByte(response?.Value));
+                }
+                return (bool)response.Value;
+            }
+
+            throw new InvalidOperationException($"Could not get Selected of element");
+        }
+
+        /// <summary>
         /// Determine if a form or form-like element (checkbox, select, etc...) is selected.
         /// </summary>
         /// <param name="element">Target Element.</param>
@@ -160,7 +190,7 @@ namespace Plugin.Maui.UITestHelpers.Appium
         public static void EnterText(this IApp app, string element, string text)
         {
             var appElement = FindElement(app, element);
-           
+
             app.EnterText(appElement, text);
         }
 
@@ -173,7 +203,7 @@ namespace Plugin.Maui.UITestHelpers.Appium
         public static void EnterText(this IApp app, IQuery query, string text)
         {
             var appElement = app.FindElement(query);
-          
+
             app.EnterText(appElement, text);
         }
 
@@ -331,7 +361,7 @@ namespace Plugin.Maui.UITestHelpers.Appium
         public static void DoubleTap(this IApp app, string element)
         {
             var elementToDoubleTap = FindElement(app, element);
-           
+
             app.DoubleTap(elementToDoubleTap);
         }
 
@@ -395,7 +425,7 @@ namespace Plugin.Maui.UITestHelpers.Appium
         public static void TouchAndHold(this IApp app, string element)
         {
             var elementToTouchAndHold = FindElement(app, element);
-         
+
             app.TouchAndHold(elementToTouchAndHold);
         }
 


### PR DESCRIPTION
Added IsChecked() Method
-Reference Issue #34 IsSelected() does not work on Android, iOS, or MAC when getting the check value of a checkbox or radio button.
-Reduced the spacing on MainPage.xaml so that the new UI elements would fit on Windows without needing to scroll
-Added Checkbox and Radio button to MainPage.xaml for demo and UI Testing of new IsChecked() Method

Notes:
The attribute to determine the check value is platform dependent.  Passing the Test Device seemed to be a concrete way of determining the attribute to get. 

Testing
The added UI Tests were run on Android, iOS, Mac, and Windows and successfully passed.

Fixes #34