### PR TITLE
Scroll rework

### DIFF
--- a/.github/workflows/ui-test-android.yml
+++ b/.github/workflows/ui-test-android.yml
@@ -11,13 +11,13 @@ on:
 env:
   BUILD_CONFIGURATION: Release
   CSPROJ_TO_BUILD: samples/Plugin.Maui.UITestHelpers.Sample/Plugin.Maui.UITestHelpers.Sample.csproj
-  APP_TO_TEST: samples/Plugin.Maui.UITestHelpers.Sample/bin/Release/net8.0-android/com.companyname.uitesthelperssample-Signed.apk
+  APP_TO_TEST: samples/Plugin.Maui.UITestHelpers.Sample/bin/Release/net9.0-android/com.companyname.uitesthelperssample-Signed.apk
   CSPROJ_TO_TEST: samples/UITests.Android/UITests.Android.csproj
   APP_ID: com.companyname.uitesthelperssample
-  TARGET_FRAMEWORK: net8.0-android
+  TARGET_FRAMEWORK: net9.0-android
   TEST_EMULATOR_NAME: UITestEmu
   ANDROID_EMULATOR_IMAGE: system-images;android-33;default;x86_64
-  SCREENCAPTURE_FOLDER: samples/UITests.Android/bin/Debug/net8.0
+  SCREENCAPTURE_FOLDER: samples/UITests.Android/bin/Debug/net9.0
   ARTIFACTS_PATH: ${{ github.workspace }}/output
 
 jobs:

--- a/.github/workflows/ui-test-ios.yml
+++ b/.github/workflows/ui-test-ios.yml
@@ -12,13 +12,13 @@ env:
   # Release builds don't run on the Simulator
   BUILD_CONFIGURATION: Debug
   CSPROJ_TO_BUILD: samples/Plugin.Maui.UITestHelpers.Sample/Plugin.Maui.UITestHelpers.Sample.csproj
-  APP_TO_TEST: samples/Plugin.Maui.UITestHelpers.Sample/bin/Debug/net8.0-ios/iossimulator-arm64/Plugin.Maui.UITestHelpers.Sample.app
+  APP_TO_TEST: samples/Plugin.Maui.UITestHelpers.Sample/bin/Debug/net9.0-ios/iossimulator-arm64/Plugin.Maui.UITestHelpers.Sample.app
   CSPROJ_TO_TEST: samples/UITests.iOS/UITests.iOS.csproj
   APP_ID: com.companyname.uitesthelperssample
-  TARGET_FRAMEWORK: net8.0-ios
+  TARGET_FRAMEWORK: net9.0-ios
   XCODE_VERSION: 16.0
   TEST_SIM_NAME: UITestSim
-  SCREENCAPTURE_FOLDER: samples/UITests.iOS/bin/Debug/net8.0
+  SCREENCAPTURE_FOLDER: samples/UITests.iOS/bin/Debug/net9.0
   ARTIFACTS_PATH: ${{ github.workspace }}/output
 
 jobs:

--- a/.github/workflows/ui-test-macos.yml
+++ b/.github/workflows/ui-test-macos.yml
@@ -11,12 +11,12 @@ on:
 env:
   BUILD_CONFIGURATION: Release
   CSPROJ_TO_BUILD: samples/Plugin.Maui.UITestHelpers.Sample/Plugin.Maui.UITestHelpers.Sample.csproj
-  APP_TO_TEST: samples/Plugin.Maui.UITestHelpers.Sample/bin/Release/net8.0-maccatalyst/maccatalyst-arm64/Plugin.Maui.UITestHelpers.Sample.app
+  APP_TO_TEST: samples/Plugin.Maui.UITestHelpers.Sample/bin/Release/net9.0-maccatalyst/maccatalyst-arm64/Plugin.Maui.UITestHelpers.Sample.app
   CSPROJ_TO_TEST: samples/UITests.macOS/UITests.macOS.csproj
   APP_ID: com.companyname.uitesthelperssample
-  TARGET_FRAMEWORK: net8.0-maccatalyst
+  TARGET_FRAMEWORK: net9.0-maccatalyst
   XCODE_VERSION: 15.2
-  SCREENCAPTURE_FOLDER: samples/UITests.macOS/bin/Debug/net8.0
+  SCREENCAPTURE_FOLDER: samples/UITests.macOS/bin/Debug/net9.0
   ARTIFACTS_PATH: ${{ github.workspace }}/output
 
 jobs:

--- a/.github/workflows/ui-test-windows.yml
+++ b/.github/workflows/ui-test-windows.yml
@@ -11,10 +11,10 @@ on:
 env:
   BUILD_CONFIGURATION: Release
   CSPROJ_TO_BUILD: samples/Plugin.Maui.UITestHelpers.Sample/Plugin.Maui.UITestHelpers.Sample.csproj
-  APP_TO_TEST: samples/Plugin.Maui.UITestHelpers.Sample/bin/Release/net8.0-windows10.0.19041.0/win10-x64/Plugin.Maui.UITestHelpers.Sample.exe
+  APP_TO_TEST: samples/Plugin.Maui.UITestHelpers.Sample/bin/Release/net9.0-windows10.0.19041.0/win10-x64/Plugin.Maui.UITestHelpers.Sample.exe
   CSPROJ_TO_TEST: samples/UITests.Windows/UITests.Windows.csproj
-  TARGET_FRAMEWORK: net8.0-windows10.0.19041.0
-  SCREENCAPTURE_FOLDER: samples/UITests.Windows/bin/Debug/net8.0
+  TARGET_FRAMEWORK: net9.0-windows10.0.19041.0
+  SCREENCAPTURE_FOLDER: samples/UITests.Windows/bin/Debug/net9.0
   ARTIFACTS_PATH: ${{ github.workspace }}/output
 
 jobs:

--- a/samples/Plugin.Maui.UITestHelpers.Sample/Plugin.Maui.UITestHelpers.Sample.csproj
+++ b/samples/Plugin.Maui.UITestHelpers.Sample/Plugin.Maui.UITestHelpers.Sample.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net9.0-android;net9.0-ios;net9.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net9.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
+		<!-- <TargetFrameworks>$(TargetFrameworks);net9.0-tizen</TargetFrameworks> -->
 		<OutputType>Exe</OutputType>
 		<RootNamespace>Plugin.Maui.UITestHelpers.Sample</RootNamespace>
 		<UseMaui>true</UseMaui>

--- a/samples/UITests.Android/UITests.Android.csproj
+++ b/samples/UITests.Android/UITests.Android.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsTestProject>true</IsTestProject>

--- a/samples/UITests.Shared/UITests.Shared.csproj
+++ b/samples/UITests.Shared/UITests.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Build.NoTargets/3.7.0">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net9.0</TargetFrameworks>
 		<GenerateAssemblyInfo>False</GenerateAssemblyInfo>
 		<GenerateMSBuildEditorConfigFile>False</GenerateMSBuildEditorConfigFile>
 		<RootNamespace>UITests</RootNamespace>

--- a/samples/UITests.Windows/UITests.Windows.csproj
+++ b/samples/UITests.Windows/UITests.Windows.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsTestProject>true</IsTestProject>

--- a/samples/UITests.iOS/UITests.iOS.csproj
+++ b/samples/UITests.iOS/UITests.iOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsTestProject>true</IsTestProject>

--- a/samples/UITests.macOS/UITests.macOS.csproj
+++ b/samples/UITests.macOS/UITests.macOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsTestProject>true</IsTestProject>

--- a/src/Plugin.Maui.UITestHelpers.Appium/HelperExtensions.cs
+++ b/src/Plugin.Maui.UITestHelpers.Appium/HelperExtensions.cs
@@ -467,15 +467,16 @@ namespace Plugin.Maui.UITestHelpers.Appium
         }
 
         /// <summary>
-        /// Scroll until an element that matches the toElementId is shown on the screen.
+        /// Scrolls within a specified element until a target element is visible or a timeout occurs.
         /// </summary>
         /// <param name="app">Represents the main gateway to interact with an app.</param>
-        /// <param name="elementToFind">Specify what element to scroll within.</param>
-        /// <param name="scrollingElement">Specify what element to scroll inside of.</param>
-        /// <param name="down">Whether scrolls should be down or up.</param>
-        /// <param name="horizontalStartPoint">Specify where to start the scroll from on X axis</param>
-        /// <param name="percentToScroll">Specify what percent to scroll with one gesture</param>
-        /// <param name="timeoutInSeconds">Specify timeout</param>
+        /// <param name="elementToFind">The ID of the element to find.</param>
+        /// <param name="scrollingElement">The ID of the element to scroll within.</param>
+        /// <param name="down">Indicates whether to scroll down (true) or up (false).</param>
+        /// <param name="horizontalStartPoint">Optional horizontal start point for the scroll.</param>
+        /// <param name="percentToScroll">The percentage of the element to scroll with each gesture.</param>
+        /// <param name="timeoutInSeconds">The maximum time to wait for the element to become visible.</param>
+        /// <exception cref="NotFoundException">Thrown if the element is not visible within the timeout period.</exception>
         public static void ScrollUntilVisible(this IApp app, string elementToFind, string scrollingElement, bool down = true, int? horizontalStartPoint = null, double percentToScroll = 0.5, int timeoutInSeconds = 30)
         {
             var timeout = TimeSpan.FromSeconds(timeoutInSeconds);
@@ -493,9 +494,18 @@ namespace Plugin.Maui.UITestHelpers.Appium
             }
 
             stopwatch.Stop();
-            throw new NotFoundException ($"Element with ID '{elementToFind}' not visible within timeout.");
+            throw new NotFoundException($"Element with ID '{elementToFind}' not visible within timeout.");
         }
 
+        /// <summary>
+        /// Scrolls within a specified element by a given percentage.
+        /// </summary>
+        /// <param name="app">Represents the main gateway to interact with an app.</param>
+        /// <param name="scrollingElement">The ID of the element to scroll within.</param>
+        /// <param name="down">Indicates whether to scroll down (true) or up (false).</param>
+        /// <param name="percentToScroll">The percentage of the element to scroll with each gesture.</param>
+        /// <param name="horizontalStartPoint">Optional horizontal start point for the scroll.</param>
+        /// <exception cref="NotFoundException">Thrown if the driver is null.</exception>
         private static void Scroll(IApp app, string scrollingElement, bool down, double percentToScroll, int? horizontalStartPoint = null)
         {
             var driver = (app as AppiumApp)?.Driver;

--- a/src/Plugin.Maui.UITestHelpers.Appium/Plugin.Maui.UITestHelpers.Appium.csproj
+++ b/src/Plugin.Maui.UITestHelpers.Appium/Plugin.Maui.UITestHelpers.Appium.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/Plugin.Maui.UITestHelpers.Core/Plugin.Maui.UITestHelpers.Core.csproj
+++ b/src/Plugin.Maui.UITestHelpers.Core/Plugin.Maui.UITestHelpers.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/Plugin.Maui.UITestHelpers.NUnit/Plugin.Maui.UITestHelpers.NUnit.csproj
+++ b/src/Plugin.Maui.UITestHelpers.NUnit/Plugin.Maui.UITestHelpers.NUnit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Functionality added to the helper methods to scroll within a specified element until a target element is visible or a timeout occurs.
The previous ScrollTo implementation has been removed.
This also resolves https://github.com/jfversluis/Plugin.Maui.UITestHelpers/issues/33