### PR TITLE
Minor fix to FindElementByText method

### DIFF
--- a/src/Plugin.Maui.UITestHelpers.Appium/AppiumIOSApp.cs
+++ b/src/Plugin.Maui.UITestHelpers.Appium/AppiumIOSApp.cs
@@ -41,7 +41,12 @@ namespace Plugin.Maui.UITestHelpers.Appium
 			}
 		}
 
-		private static AppiumOptions GetOptions(IConfig config)
+        public override IUIElement FindElementByText(string text)
+        {
+            return AppiumQuery.ByXPath("//*[@label='" + text + "']").FindElement(this);
+        }
+
+        private static AppiumOptions GetOptions(IConfig config)
 		{
 			config.SetProperty("PlatformName", "iOS");
 			config.SetProperty("AutomationName", "XCUITest");


### PR DESCRIPTION
The ios element detection by text seemed to not work very well.
This pr provides an override for the FindElementByText method to target by xpath using the label. This seems to work reliably hence the changes to the Appium IosApp class. 