### PR TITLE
Send keys conditional check if keyboard is shown first

### DIFF
--- a/src/Plugin.Maui.UITestHelpers.Appium/HelperExtensions.cs
+++ b/src/Plugin.Maui.UITestHelpers.Appium/HelperExtensions.cs
@@ -182,7 +182,10 @@ namespace Plugin.Maui.UITestHelpers.Appium
             if (element is not null)
             {
                 element.SendKeys(text);
-                app.DismissKeyboard();
+                if (app.IsKeyboardShown())
+                {
+                    app.DismissKeyboard();
+                }
             }
         }
 


### PR DESCRIPTION
It's been noted the DismissKeyboard() behaved at times unusually when called on an element which accepts text/focuses but doesnt prompt the keyboard. 
This has been addressed in this pr by adding a small check to only hide it if prompted when sending keys.